### PR TITLE
Remove fixed width/height of 500px from decision graph svg

### DIFF
--- a/assets/img/decision-graph.svg
+++ b/assets/img/decision-graph.svg
@@ -2,8 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="500px" height="500px"
-     viewBox="0.00 -3937.00 2982.16 4000.00"
+<svg viewBox="0.00 -3937.00 2982.16 4000.00"
 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" >
 
 <script xlink:href="../js/svgpan.js"/>


### PR DESCRIPTION
This makes it default to full size when viewed alone, but does not change the appearance of the embedding in the tutorial.